### PR TITLE
fix: exposed apis

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,7 +7,16 @@ export default function App() {
   const profileId = process.env.PROFILE_ID;
 
   return publishableKey && profileId ? (
-    <HyperProvider publishableKey={publishableKey} profileId={profileId}>
+    <HyperProvider
+      options={{
+        publishableKey,
+        profileId,
+        // customConfig: {
+        //   backendEndpoint: process.env.HYPERSWITCH_CUSTOM_BACKEND_URL,
+        //   loggingEndpoint: process.env.HYPERSWITCH_CUSTOM_LOG_URL,
+        // },
+      }}
+    >
       <PaymentScreen />
     </HyperProvider>
   ) : (

--- a/example/src/PaymentScreen.tsx
+++ b/example/src/PaymentScreen.tsx
@@ -1,10 +1,9 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { View, Text, TextInput, TouchableOpacity } from 'react-native';
 import {
   useHyper,
   PaymentWidget,
-  type InitPaymentSessionParams,
-  type InitPaymentSessionResult,
+  HyperElements,
   type PresentPaymentSheetResult,
 } from '@juspay-tech/react-native-hyperswitch';
 import {
@@ -16,14 +15,13 @@ import {
 import { styles } from './styles';
 
 export default function PaymentScreen() {
-  const { initPaymentSession, presentPaymentSheet } = useHyper();
   const [status, setStatus] = useState<string | null | undefined>(null);
   const [message, setMessage] = useState<string | null | undefined>(null);
   const [baseURL, setBaseURL] = useState<string>(initialBaseUrl);
   const [clientSecret, setClientSecret] = useState<string | null | undefined>(null);
   const [sdkAuthorisation, setSdkAuthorisation] = useState<string | null | undefined>(null);
 
-  const createPaymentIntent = useCallback(async (): Promise<string> => {
+  const createPaymentIntent = useCallback(async (): Promise<void> => {
     const response = await fetch(`${baseURL}/create-payment-intent`);
     const data = await response.json();
     if (!response.ok) {
@@ -31,31 +29,67 @@ export default function PaymentScreen() {
     }
     setClientSecret(data.clientSecret);
     setSdkAuthorisation(data.sdkAuthorisation);
-    return data.clientSecret;
+    setStatus('Ready to checkout');
+    setMessage(null);
   }, [baseURL]);
 
-  const setup = useCallback(async (): Promise<void> => {
-    const paymentIntent = await createPaymentIntent();
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.textInput}
+        placeholder="Enter base URL"
+        value={baseURL}
+        onChangeText={(text) => setBaseURL(text)}
+      />
+      <TouchableOpacity style={styles.button} onPress={createPaymentIntent}>
+        <Text style={styles.buttonText}>Load client Secret</Text>
+      </TouchableOpacity>
 
-    if (paymentIntent !== undefined) {
-      const params: InitPaymentSessionParams = {
-        paymentIntentClientSecret: paymentIntent,
-        sdkAuthorisation: sdkAuthorisation,
-      };
-      const result: InitPaymentSessionResult = await initPaymentSession(params);
-      if (result.error) {
-        throw new Error(result.error);
-      } else {
-        setStatus('Ready to checkout');
-        setMessage(null);
-      }
-    }
-  }, [initPaymentSession, createPaymentIntent]);
+      {clientSecret && (
+        <HyperElements
+          options={{
+            clientSecret,
+            sdkAuthorisation: sdkAuthorisation || undefined,
+          }}
+        >
+          <PaymentScreenContent
+            status={status}
+            message={message}
+            setStatus={setStatus}
+            setMessage={setMessage}
+          />
+        </HyperElements>
+      )}
+    </View>
+  );
+}
+
+// Inner component that has access to HyperElements context
+function PaymentScreenContent({
+  status,
+  message,
+  setStatus,
+  setMessage,
+}: {
+  status: string | null | undefined;
+  message: string | null | undefined;
+  setStatus: (s: string | null | undefined) => void;
+  setMessage: (m: string | null | undefined) => void;
+}) {
+  const { presentPaymentSheet, isReady } = useHyper();
+  // const { confirmPayment } = useHyper();
 
   const checkout = async (): Promise<void> => {
+    if (!isReady) {
+      setStatus('Not ready');
+      setMessage('Please wait for the session to initialize');
+      return;
+    }
+
     try {
       const { error, paymentResult }: PresentPaymentSheetResult =
         await presentPaymentSheet(getCustomisationOptions());
+
       if (error) {
         console.error('Payment failed:', JSON.stringify(error, null, 2));
         setStatus(`Payment failed: ${error.code}`);
@@ -71,31 +105,12 @@ export default function PaymentScreen() {
     } catch (error: any) {
       console.error('Checkout failed:', error);
       setStatus(`Checkout failed`);
-      setMessage(error.message);
+      setMessage(getErrorMessage(error));
     }
   };
 
-  useEffect(() => {
-    try {
-      setup();
-    } catch (error) {
-      console.error('Setup failed:', error);
-      setStatus('Setup Error:');
-      setMessage(getErrorMessage(error));
-    }
-  }, [setup]);
-
   return (
-    <View style={styles.container}>
-      <TextInput
-        style={styles.textInput}
-        placeholder="Enter base URL"
-        value={baseURL}
-        onChangeText={(text) => setBaseURL(text)}
-      />
-      <TouchableOpacity style={styles.button} onPress={setup}>
-        <Text style={styles.buttonText}>Reload client Secret</Text>
-      </TouchableOpacity>
+    <>
       <TouchableOpacity style={styles.button} onPress={checkout}>
         <Text style={styles.buttonText}>Checkout</Text>
       </TouchableOpacity>
@@ -116,8 +131,10 @@ export default function PaymentScreen() {
           }
         }}
         style={{ width: '100%', height: 400 }}
-        options={{ ...getCustomisationOptions('accordion'), clientSecret: clientSecret, sdkAuthorisation: sdkAuthorisation }}
+        options={{
+          ...getCustomisationOptions('accordion'),
+        }}
       />
-    </View>
+    </>
   );
 }

--- a/packages/@juspay-tech/react-native-hyperswitch/src/context/HyperElements.res
+++ b/packages/@juspay-tech/react-native-hyperswitch/src/context/HyperElements.res
@@ -1,0 +1,85 @@
+open HyperTypes
+
+@genType
+type hyperElementsContext = {
+  isSessionInitialized: bool,
+  sdkAuthorisation?: string,
+  clientSecret?: string,
+}
+
+let defaultContext: hyperElementsContext = {
+  isSessionInitialized: false,
+}
+
+let hyperElementsContext = React.createContext(defaultContext)
+
+module Provider = {
+  let make = React.Context.provider(hyperElementsContext)
+}
+
+@genType @react.component
+let make = (
+  ~children: React.element,
+  ~options: hyperElementsOptions,
+) => {
+  // Get HyperProvider context to check initialization
+  let (providerData, _) = React.useContext(HyperProvider.hyperProviderContext)
+
+  // Extract session configuration
+  let sdkAuthorisation = options.sdkAuthorisation
+  let clientSecret = options.clientSecret
+
+  // State for session initialization
+  let (sessionState, setSessionState) = React.useState(() => {
+    isSessionInitialized: false,
+    ?sdkAuthorisation,
+    ?clientSecret,
+  })
+
+  // Initialize payment session
+  let initialiseSession = async () => {
+    let authValue = switch sdkAuthorisation {
+    | Some(auth) => auth
+    | None =>
+      switch clientSecret {
+      | Some(secret) => secret
+      | None => ""
+      }
+    }
+
+    if (authValue != "") {
+      try {
+        let _ = await NativeHyperswitchSdk.nativeHyperswitchSdk.initPaymentSession(
+          ~paymentIntentClientSecret=authValue,
+        )
+        setSessionState(_ => {
+          isSessionInitialized: true,
+          ?sdkAuthorisation,
+          ?clientSecret,
+        })
+      } catch {
+      | _ =>
+        setSessionState(_ => {
+          isSessionInitialized: false,
+          ?sdkAuthorisation,
+          ?clientSecret,
+        })
+      }
+    }
+  }
+
+  React.useEffect1(() => {
+    if providerData.isInitialized {
+      initialiseSession()->ignore
+    }
+    None
+  }, [providerData.isInitialized])
+
+  <Provider value={sessionState}>
+    children
+  </Provider>
+}
+
+let useHyperElements = () => {
+  React.useContext(hyperElementsContext)
+}

--- a/packages/@juspay-tech/react-native-hyperswitch/src/context/HyperProvider.res
+++ b/packages/@juspay-tech/react-native-hyperswitch/src/context/HyperProvider.res
@@ -1,16 +1,15 @@
-type hyperProviderData = {
-  publishableKey: string,
-  profileId: string,
+@genType
+type customConfig = {
   customBackendUrl?: string,
   customLogUrl?: string,
-  customParams?: Js.Json.t,
-  isInitialized: bool,
-  error?: string,
+  customParams?: JSON.t,
 }
 
-type result = {
-  paymentResult: string,
-  error: string
+@genType
+type hyperProviderOptions = {
+  publishableKey: string,
+  profileId: string,
+  customConfig?: customConfig,
 }
 
 type widgetState = {
@@ -32,9 +31,21 @@ let unregisterWidget = (id: string) => {
   Dict.delete(widgetRegistry.contents, id)
 }
 
+let getWidgetState = (id: string): option<widgetState> => {
+  Js.Dict.get(widgetRegistry.contents, id)
+}
+
+type hyperProviderData = {
+  options: hyperProviderOptions,
+  isInitialized: bool,
+  error?: string,
+}
+
 let defaultVal: hyperProviderData = {
-  publishableKey: "",
-  profileId: "",
+  options: {
+    publishableKey: "",
+    profileId: "",
+  },
   isInitialized: false,
 }
 
@@ -55,20 +66,26 @@ let initHyperswitch = (~publishableKey, ~customBackendUrl=?, ~customLogUrl=?, ~c
 }
 
 @genType @react.component
-let make = (
-  ~children: React.element,
-  ~publishableKey,
-  ~profileId,
-  ~customBackendUrl=?,
-  ~customLogUrl=?,
-  ~customParams=?,
-) => {
+let make = (~children: React.element, ~options: hyperProviderOptions) => {
+  let publishableKey = options.publishableKey
+  let _profileId = options.profileId
+  let customConfig = options.customConfig
+
+  let customBackendUrl = switch customConfig {
+  | Some(config) => config.customBackendUrl
+  | None => None
+  }
+  let customLogUrl = switch customConfig {
+  | Some(config) => config.customLogUrl
+  | None => None
+  }
+  let customParams = switch customConfig {
+  | Some(config) => config.customParams
+  | None => None
+  }
+
   let (state, setState) = React.useState(_ => {
-    publishableKey,
-    profileId,
-    ?customBackendUrl,
-    ?customLogUrl,
-    ?customParams,
+    options,
     isInitialized: false,
   })
 
@@ -76,10 +93,15 @@ let make = (
 
   let initialise = async () => {
     try {
-      let _ = await initHyperswitch(~publishableKey, ~customBackendUrl?, ~customLogUrl?, ~customParams?)
+      let _ = await initHyperswitch(
+        ~publishableKey,
+        ~customBackendUrl?,
+        ~customLogUrl?,
+        ~customParams?,
+      )
       setState(_ => {
         ...state,
-        isInitialized:true,
+        isInitialized: true,
       })
     } catch {
     | Exn.Error(obj) =>
@@ -92,7 +114,7 @@ let make = (
   }
 
   React.useEffect1(() => {
-    if (publishableKey != "") {
+    if publishableKey != "" {
       initialise()->ignore
     }
     None

--- a/packages/@juspay-tech/react-native-hyperswitch/src/hooks/useHyper.res
+++ b/packages/@juspay-tech/react-native-hyperswitch/src/hooks/useHyper.res
@@ -11,52 +11,28 @@ let getError: (~error: string=?) => presentPaymentSheetResult = (
   }
 }
 
-let _initPaymentSession = async (params: initPaymentSessionParams): initPaymentSessionResult => {
-  try {
-    await nativeHyperswitchSdk.initPaymentSession(
-      ~paymentIntentClientSecret=params.paymentIntentClientSecret->Option.getOr(""),
-    )
-    {}
-  } catch {
-  | Exn.Error(obj) =>
-    switch Exn.message(obj) {
-    | Some(msg) => {error: msg}
-    | None => {error: "Unknown error occurred while initializing payment sheet"}
-    }
-  | _ => {error: "Unexpected error occurred while initializing payment sheet"}
-  }
-}
-let getData = (data, ~key : string, ~fallback : string)=>{
+let getData = (data, ~key: string, ~fallback: string) => {
   data
-  ->Option.flatMap(obj =>
-        obj->Js.Dict.get(key)->Option.flatMap(json => json->Js.Json.decodeString)
-      )
-      ->Option.getOr(fallback)
+  ->Option.flatMap(obj => obj->Dict.get(key)->Option.flatMap(json => json->JSON.Decode.string))
+  ->Option.getOr(fallback)
 }
 
 let parsePaymentSheetResult = (result: 'a): presentPaymentSheetResult => {
   try {
     let parsed = switch Js.typeof(result) {
-    | "string" => Js.Json.parseExn(result)
+    | "string" => JSON.parseExn(result)
     | _ => result->Obj.magic
     }
-    let decodedObject = parsed->Js.Json.decodeObject
+    let decodedObject = parsed->JSON.Decode.object
 
-    let status =
-      decodedObject->getData(~key="status", ~fallback="failed")
-    let errorMessage =
-      decodedObject->getData(~key="error", ~fallback="")
-    
+    let status = decodedObject->getData(~key="status", ~fallback="failed")
+    let errorMessage = decodedObject->getData(~key="error", ~fallback="")
 
-    let code =
-      decodedObject->getData(~key="code", ~fallback="")
+    let code = decodedObject->getData(~key="code", ~fallback="")
 
-    let typeData =
-      decodedObject->getData(~key="type", ~fallback="")
-      
-    let message =
-      decodedObject
-      ->getData(~key="message", ~fallback="failed")
+    let typeData = decodedObject->getData(~key="type", ~fallback="")
+
+    let message = decodedObject->getData(~key="message", ~fallback="failed")
 
     let paymentResult = {
       status,
@@ -110,19 +86,25 @@ let _presentPaymentSheet = async (params: presentPaymentSheetParams): presentPay
   }
 }
 
+@genType
 type useHyper = {
-  initPaymentSession: initPaymentSessionParams => promise<initPaymentSessionResult>,
+  // confirmPayment: unit => promise<presentPaymentSheetResult>,
   presentPaymentSheet: presentPaymentSheetParams => promise<presentPaymentSheetResult>,
+  isReady: bool,
+  isSessionInitialized: bool,
 }
 
 @genType
-let useHyper = () => {
-  let (contextData, _) = React.useContext(HyperProvider.hyperProviderContext)
-  let isReady = contextData.isInitialized && contextData.error->Belt.Option.isNone
+let useHyper = (): useHyper => {
+  let (providerData, _) = React.useContext(HyperProvider.hyperProviderContext)
+  let hyperElements = React.useContext(HyperElements.hyperElementsContext)
 
-  let initPaymentSession = React.useCallback0((params: initPaymentSessionParams) => {
-    _initPaymentSession(params)
-  })
+  let isProviderReady = providerData.isInitialized && providerData.error->Option.isNone
+  let isSessionInitialized = hyperElements.isSessionInitialized
+  let isReady = isProviderReady && isSessionInitialized
+
+  let clientSecret = hyperElements.clientSecret
+  let sdkAuthorisation = hyperElements.sdkAuthorisation
 
   let presentPaymentSheet = React.useCallback1((params: presentPaymentSheetParams) => {
     if !isReady {
@@ -135,8 +117,27 @@ let useHyper = () => {
     }
   }, [isReady])
 
+  // Confirm payment - for headless flow
+  // let confirmPayment = React.useCallback3(() => {
+  //   if !isReady {
+  //     let a: promise<presentPaymentSheetResult> = Promise.resolve(
+  //       getError(~error="Hyperswitch is not initialized or session is not ready"),
+  //     )
+  //     a
+  //   } else {
+  //     // Build params from context
+  //     let params: presentPaymentSheetParams = {
+  //       ?clientSecret,
+  //       ?sdkAuthorisation,
+  //     }
+  //     _presentPaymentSheet(params)
+  //   }
+  // }, (isReady, clientSecret, sdkAuthorisation))
+
   {
-    initPaymentSession,
+    // confirmPayment,
     presentPaymentSheet,
+    isReady,
+    isSessionInitialized,
   }
 }

--- a/packages/@juspay-tech/react-native-hyperswitch/src/index.tsx
+++ b/packages/@juspay-tech/react-native-hyperswitch/src/index.tsx
@@ -1,14 +1,68 @@
+// Core type definitions
+export type {
+  customConfig as CustomConfig,
+  hyperProviderOptions as HyperProviderOptions,
+  hyperElementsOptions as HyperElementsOptions,
+  configuration as Configuration,
+  widgetElementOptions as WidgetElementOptions,
+} from './types/HyperTypes.gen';
+
+// Payment sheet configuration types
+export type {
+  options as PaymentSheetOptions,
+  appearance as Appearance,
+  colors as Colors,
+  colorType as ColorType,
+  shapes as Shapes,
+  font as Font,
+  primaryButton as PrimaryButton,
+  customerConfiguration as CustomerConfiguration,
+  addressDetails as AddressDetails,
+  address as Address,
+  phone as Phone,
+  placeholder as Placeholder,
+  localeTypes as LocaleTypes,
+  themeType as ThemeType,
+  layoutType as LayoutType,
+  googlePayConfiguration as GooglePayConfiguration,
+  googlePayButtonType as GooglePayButtonType,
+  applePayConfiguration as ApplePayConfiguration,
+  applePayButtonType as ApplePayButtonType,
+  applePayButtonStyle as ApplePayButtonStyle,
+  googlePayButtonStyle as GooglePayButtonStyle,
+  googlePayThemeBaseStyle as GooglePayThemeBaseStyle,
+  applePayThemeBaseStyle as ApplePayThemeBaseStyle,
+  primaryButtonColor as PrimaryButtonColor,
+  primaryButtonColorType as PrimaryButtonColorType,
+  fontFamilyTypes as FontFamilyTypes,
+} from './types/PaymentSheetConfiguration.gen';
+
+// Native module types
+export type {
+  paymentResult as PaymentResult,
+  paymentResultEvent as PaymentResultEvent,
+  widgetType as WidgetType,
+} from './types/NativeModuleTypes.gen';
+
+// SDK operation types
 export type {
   initPaymentSessionParams as InitPaymentSessionParams,
   initPaymentSessionResult as InitPaymentSessionResult,
   presentPaymentSheetParams as PresentPaymentSheetParams,
   presentPaymentSheetResult as PresentPaymentSheetResult,
+  paymentResult as SdkPaymentResult,
+  error as SdkError,
 } from './modules/NativeHyperswitchSdk.gen';
 
 export {
   make as HyperProvider,
   initHyperswitch,
 } from './context/HyperProvider.gen';
+
+export {
+  make as HyperElements,
+  useHyperElements,
+} from './context/HyperElements.gen';
 
 export {
   make as PaymentWidget,

--- a/packages/@juspay-tech/react-native-hyperswitch/src/modules/NativeHyperswitchSdk.res
+++ b/packages/@juspay-tech/react-native-hyperswitch/src/modules/NativeHyperswitchSdk.res
@@ -3,7 +3,7 @@ type initialise = (
   ~publishableKey: string,
   ~customBackendUrl: string=?,
   ~customLogUrl: string=?,
-  ~customParams: Js.Json.t=?,
+  ~customParams: JSON.t=?,
 ) => promise<unit>
 
 type initPaymentSession = (~paymentIntentClientSecret: string) => promise<unit>

--- a/packages/@juspay-tech/react-native-hyperswitch/src/types/HyperTypes.res
+++ b/packages/@juspay-tech/react-native-hyperswitch/src/types/HyperTypes.res
@@ -1,0 +1,19 @@
+// Options for HyperElements - payment session configuration
+@genType
+type hyperElementsOptions = {
+  sdkAuthorisation?: string,
+  clientSecret?: string,
+}
+
+// Widget-specific element options
+@genType
+type widgetElementOptions = {
+  // Widget-specific options
+}
+
+// Configuration for PaymentWidget
+@genType
+type configuration = {
+  elementOptions?: widgetElementOptions,
+  appearance?: PaymentSheetConfiguration.appearance,
+}

--- a/packages/@juspay-tech/react-native-hyperswitch/src/views/PaymentWidget.res
+++ b/packages/@juspay-tech/react-native-hyperswitch/src/views/PaymentWidget.res
@@ -1,3 +1,5 @@
+open HyperTypes
+
 @module("react-native") @scope("UIManager")
 external dispatchViewManagerCommand: (
   ~viewId: int,
@@ -33,9 +35,13 @@ let createView = viewId => {
 let make = (
   ~widgetId,
   ~onPaymentResult,
-  ~options: option<PaymentSheetConfiguration.options>=?,
+  ~options: option<configuration>=?,
   ~style: option<ReactNative.Style.t>=?,
 ) => {
+  let hyperElements = React.useContext(HyperElements.hyperElementsContext)
+  let clientSecret = hyperElements.clientSecret
+  let sdkAuthorisation = hyperElements.sdkAuthorisation
+
   let (viewId, setViewId) = React.useState(_ => None)
   let viewRef: React.ref<Nullable.t<unit>> = React.useRef(Nullable.null)
   // run after mount
@@ -61,16 +67,28 @@ let make = (
     onPaymentResult(event.nativeEvent.result->Option.getOr("")->parse)
   }
 
+  let paymentSheetOptions: option<PaymentSheetConfiguration.options> = switch options {
+  | Some(config) =>
+    Some({
+      clientSecret: ?clientSecret,
+      sdkAuthorisation: ?sdkAuthorisation,
+      appearance: ?config.appearance,
+    })
+  | None =>
+    Some({
+      clientSecret: ?clientSecret,
+      sdkAuthorisation: ?sdkAuthorisation,
+    })
+  }
+
   <NativePaymentWidget
     ref={viewRef}
     widgetId={widgetId}
     widgetType={"widgetPaymentSheet"}
-    clientSecret=?{switch options {
-      | Some(options) => options.clientSecret
-      | None => None
-    }}
+    ?clientSecret
+    ?sdkAuthorisation
     onPaymentResult={onPaymentResultInternal}
-    options=?options
-    style=?style
+    options=?paymentSheetOptions
+    ?style
   />
 }


### PR DESCRIPTION
# FIX (BREAKING CHANGE)
- This PR refactors the apis exposed for react-native widgets integration.
- Proposed api: 
```
customConfig = { backendEndpoint, assetEndpoint, sdkConfigEndpoint, loggingEndpoint }
const configuration = { elementOptions, appearance }

<HyperProvider options={publishableKey, profileId, customConfig}>
     <HyperElements options={sdkAuthorisationForPayments or clientSecret}>
            <PaymentWidget options={configuration} />
     </HyperElements>
</HyperProvider>
```

- Before:
```
<HyperProvider publishableKey={publishableKey} profileId={profileId}>
    <PaymentWidget
        widgetId="payment-widget"
        onPaymentResult={(result: any) => {}}
        style={{ width: '100%', height: 400 }}
        options={{ getCustomisationOptions(), clientSecret, sdkAuthorisation }}
    />
</HyperProvider>
```