### PR TITLE
fix: refactored exposed apis

### DIFF
--- a/packages/@juspay-tech/react-native-hyperswitch/ios/Views/Native/NativePaymentWidget.swift
+++ b/packages/@juspay-tech/react-native-hyperswitch/ios/Views/Native/NativePaymentWidget.swift
@@ -89,7 +89,7 @@ internal class NativePaymentWidgetView: UIView, RNResponseHandler {
         if let onPaymentResult = onPaymentResult,
            let response = response  {
             onPaymentResult(["result": response])
-            // TODO: temp 
+            // TODO: temp
             self.rootView?.removeFromSuperview()
         }
     }

--- a/packages/@juspay-tech/react-native-hyperswitch/src/core/Hyper.res
+++ b/packages/@juspay-tech/react-native-hyperswitch/src/core/Hyper.res
@@ -10,6 +10,7 @@ type globalConfig = {
   profileId: string,
   customBackendUrl?: string,
   customLogUrl?: string,
+  customAssetUrl?: string,
   customParams?: Js.Json.t,
 }
 
@@ -24,6 +25,7 @@ let setGlobalConfig = (
   ~customBackendUrl: option<string>=?,
   ~customLogUrl: option<string>=?,
   ~customParams: option<Js.Json.t>=?,
+  ~customAssetUrl: option<string>=?,
 ) => {
   globalConfigRef := Some({
     publishableKey: publishableKey,
@@ -31,6 +33,7 @@ let setGlobalConfig = (
     ?customBackendUrl,
     ?customLogUrl,
     ?customParams,
+    ?customAssetUrl,
   })
 }
 
@@ -115,6 +118,7 @@ let init = (
 ): promise<HyperTypes.hyperInstance> => {
   let backendUrl = getStringFromConfig(customConfig, "customBackendUrl")
   let logUrl = getStringFromConfig(customConfig, "customLogUrl")
+  let assetUrl = getStringFromConfig(customConfig, "customAssetUrl")
   let params = customConfig
 
   // Store config globally using function parameters
@@ -124,6 +128,7 @@ let init = (
     ~customBackendUrl=?backendUrl,
     ~customLogUrl=?logUrl,
     ~customParams=?params,
+    ~customAssetUrl=?assetUrl,
   )
 
   // Return a promise of hyperInstance (actual initialization happens in HyperElements)

--- a/packages/@juspay-tech/react-native-hyperswitch/src/core/HyperElements.res
+++ b/packages/@juspay-tech/react-native-hyperswitch/src/core/HyperElements.res
@@ -65,8 +65,11 @@ let initializeNativeSdk = async (
   ~publishableKey: string,
   ~customBackendUrl: option<string>,
   ~customLogUrl: option<string>,
+  ~customAssetUrl as _: option<string>,
   ~customParams: option<Js.Json.t>,
 ) => {
+  // NOTE: we can ignore customAssetUrl for now since it's not used in the native SDK initialization,
+  // but we include it in the parameters for future compatibility
   await NativeHyperswitchSdk.nativeHyperswitchSdk.initialise(
     ~publishableKey,
     ~customBackendUrl,
@@ -108,6 +111,7 @@ let make = (
               ~publishableKey=config.publishableKey,
               ~customBackendUrl=config.customBackendUrl,
               ~customLogUrl=config.customLogUrl,
+              ~customAssetUrl=config.customAssetUrl,
               ~customParams=config.customParams,
             )
 


### PR DESCRIPTION
## FIXED 
- exposed apis

## CHANGED:
```tsx
import { HyperInit } from '@juspay-tech/react-native-hyperswitch';
HyperInit(publishableKey, profileId)

const hyperElementsOptions: HyperElementsOptions = {
    clientSecret: clientSecret ?? undefined,
    sdkAuthorisationForPayments: sdkAuthorisation ?? undefined,
  };
<HyperElements hyper={hyperPromise} options={hyperElementsOptions}>
        <PaymentWidget
          widgetId="payment-widget"
          onPaymentResult={(result: any) => {
            console.log('Payment Result from Widget:', result);
            if (result.errorMessage) {
              setStatus(`Payment failed: ${result.errorMessage}`);
              setMessage(null);
            } else {
              setStatus(getStatus(result?.status));
              setMessage(result?.status);
            }
          }}
          style={{ width: '100%', height: 400 }}
          options={{ 
            ...getCustomisationOptions('accordion'), 
          }}
        />
</HyperElements>
```

Deprecated `useHyper` and `HyperProvider`


## IMPLEMENTATION
- `HyperInit` stores the global variables in a global context.
- `HyperElement` resolves the `hyperPromise` and internally initailizes the nativeModule with `pk_key` and other configs (internally initializing the PaymentSession object on native layer).
- `PaymentWidget` presents the widget using the clientSecret.