### PR TITLE
fix(ios): use explicit iOS version in podspec

### DIFF
--- a/packages/@juspay-tech/react-native-hyperswitch/HyperswitchSdkReactNative.podspec
+++ b/packages/@juspay-tech/react-native-hyperswitch/HyperswitchSdkReactNative.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
+  s.platforms    = { :ios => '15.1' }
   s.source       = { :git => "https://github.com/juspay/@juspay-tech/react-native-hyperswitch.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"


### PR DESCRIPTION
## Problem
The `HyperswitchSdkReactNative.podspec` used undefined variable `min_ios_version_supported`, causing CocoaPods installation to fail with:
```
undefined local variable or method 'min_ios_version_supported' for module Pod
```

## Solution
Replace the undefined variable with explicit version string `'15.1'`.

## Testing
- Local npm package integration tested successfully
- iOS pod now installs correctly to `Pods/Target Support Files/HyperswitchSdkReactNative/`
- Android autolinking continues to work

## Related
- Fixes integration blocking issue found during local package testing